### PR TITLE
feat: add templates for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug or issue
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce:
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots.
+
+## Environment
+
+- OS: [e.g. macOS, Windows, Linux]
+- Node version: [e.g. 18.17.0]
+- Next.js version: [e.g. 15.0.0]
+
+## Additional context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/beefysalad/nexion
+    about: Check the README for common questions
+  - name: Discussions
+    url: https://github.com/beefysalad/nexion/discussions
+    about: Ask questions and discuss ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a new feature
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+
+Clear description of the feature you'd like to see.
+
+## Problem it solves
+
+What problem does this feature solve?
+
+## Proposed solution
+
+How do you think this should work?
+
+## Alternatives considered
+
+Any alternative solutions you've thought about?
+
+## Additional context
+
+Any other context, mockups, or examples.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,19 @@
+---
+name: Question
+about: Ask a question about the template
+title: '[QUESTION] '
+labels: question
+assignees: ''
+---
+
+## Your Question
+
+Ask away!
+
+## What you've tried
+
+Have you checked the docs or searched existing issues?
+
+## Additional context
+
+Any other info that might help.


### PR DESCRIPTION
## Description

- add template for github issues


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced new GitHub issue templates for bug reports, feature requests, and general questions, providing structured forms with relevant fields and guidance to help users submit clearer, higher-quality issues
  * Configured issue template settings to enable blank issues and provide convenient quick-access links to Documentation and Discussions resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->