### PR TITLE
feat: add clean and restore script

### DIFF
--- a/components/dashboard/index.tsx
+++ b/components/dashboard/index.tsx
@@ -85,13 +85,11 @@ const DashboardComponent = () => {
             </span>
           </h1>
           <p className="mt-2 text-zinc-600 dark:text-neutral-400">
-            Everything looks good today. Here's what you can do next.
+            Everything looks good today. Here&apos;s what you can do next.
           </p>
         </div>
 
-        {/* Stats Grid */}
         <div className="mb-8 grid gap-6 md:grid-cols-2">
-          {/* User Stats Card */}
           <div className="group relative overflow-hidden rounded-2xl border border-zinc-200 bg-white p-6 transition-all hover:border-zinc-900 hover:shadow-xl hover:shadow-zinc-200/50 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-50 dark:hover:shadow-none">
             <div className="mb-4 inline-flex size-10 items-center justify-center rounded-xl bg-zinc-50 text-zinc-500 transition-colors group-hover:bg-zinc-900 group-hover:text-white dark:bg-neutral-800 dark:text-neutral-400 dark:group-hover:bg-neutral-50 dark:group-hover:text-neutral-900">
               <Users className="size-5" />

--- a/components/docs/getting-started.tsx
+++ b/components/docs/getting-started.tsx
@@ -65,6 +65,30 @@ npm run dev`}</code>
           </div>
         </div>
       </div>
+
+      <div className="rounded-2xl border border-zinc-200 bg-zinc-50/50 p-8 dark:border-neutral-800 dark:bg-neutral-900/30">
+        <h3 className="mb-4 text-xl font-bold">Creating a Clean Boilerplate</h3>
+        <p className="mb-4 text-zinc-600 dark:text-neutral-400">
+          If you want to remove the sample UI pages (like this docs page, the
+          landing page, and the example dashboard) to start entirely fresh, you
+          can run the cleanup command:
+        </p>
+        <div className="mb-6 rounded-xl border border-zinc-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+          <pre className="overflow-x-auto text-sm">
+            <code>npm run clean</code>
+          </pre>
+        </div>
+
+        <p className="mb-4 text-zinc-600 dark:text-neutral-400">
+          If you change your mind and want the sample pages back, you can
+          restore them easily.
+        </p>
+        <div className="mb-2 rounded-xl border border-zinc-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+          <pre className="overflow-x-auto text-sm">
+            <code>npm run restore</code>
+          </pre>
+        </div>
+      </div>
     </section>
   )
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -114,6 +114,8 @@ This file serves as the primary source of truth for AI agents working on this pr
 - `npm run lint`: Run ESLint.
 - `npm run db:seed`: Seed the database.
 - `npx prisma studio`: Open Prisma Studio.
+- `npm run clean`: Clears the repository of sample UI pages (docs, landing, dashboard) and sets up a clean Next.js boilerplate.
+- `npm run restore`: Reverts the `npm run clean` changes and restores the sample pages back into their original locations.
 
 ## Documentation & Tracking
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "next-prisma-boilerplate",
+  "name": "nexion",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "next-prisma-boilerplate",
+      "name": "nexion",
       "version": "0.1.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-prisma-boilerplate",
+  "name": "nexion",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -9,7 +9,9 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "db:seed": "tsx prisma/seed.ts"
+    "db:seed": "tsx prisma/seed.ts",
+    "clean": "node scripts/cleanup.mjs",
+    "restore": "node scripts/restore.mjs"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",

--- a/scripts/cleanup.mjs
+++ b/scripts/cleanup.mjs
@@ -1,0 +1,91 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const projectRoot = path.join(__dirname, '..')
+const sampleContentDir = path.join(projectRoot, '_sample_content')
+
+// Create sample content directory if it doesn't exist
+if (!fs.existsSync(sampleContentDir)) {
+  fs.mkdirSync(sampleContentDir, { recursive: true })
+}
+
+const itemsToMove = [
+  'app/docs',
+  'components/docs',
+  'components/landing',
+  'components/dashboard',
+]
+
+console.log('Moving sample content to _sample_content directory...')
+
+itemsToMove.forEach((itemPath) => {
+  const sourcePath = path.join(projectRoot, itemPath)
+  if (fs.existsSync(sourcePath)) {
+    const destPath = path.join(sampleContentDir, itemPath)
+    const targetDir = path.dirname(destPath)
+
+    if (!fs.existsSync(targetDir)) {
+      fs.mkdirSync(targetDir, { recursive: true })
+    }
+
+    fs.renameSync(sourcePath, destPath)
+    console.log(`Moved: ${itemPath}`)
+  } else {
+    console.log(`Skipped: ${itemPath} (not found)`)
+  }
+})
+
+console.log('Overwriting sample pages with minimal boilerplate...')
+
+// Overwrite app/page.tsx
+const appPagePath = path.join(projectRoot, 'app/page.tsx')
+const appPageContent = `export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <h1 className="text-4xl font-bold">Next.js Boilerplate</h1>
+      <p className="mt-4 text-xl">Get started by editing <code>app/page.tsx</code></p>
+    </main>
+  )
+}
+`
+if (fs.existsSync(appPagePath)) {
+  // Move old page.tsx to _sample_content too
+  const oldAppPageDest = path.join(sampleContentDir, 'app/page.tsx')
+  const oldAppPageDir = path.dirname(oldAppPageDest)
+  if (!fs.existsSync(oldAppPageDir))
+    fs.mkdirSync(oldAppPageDir, { recursive: true })
+  fs.copyFileSync(appPagePath, oldAppPageDest)
+
+  fs.writeFileSync(appPagePath, appPageContent)
+  console.log('Reset: app/page.tsx')
+}
+
+// Overwrite app/dashboard/page.tsx
+const appDashboardPagePath = path.join(projectRoot, 'app/dashboard/page.tsx')
+const appDashboardPageContent = `export default function DashboardPage() {
+  return (
+    <div className="flex flex-col h-full items-center justify-center mt-20">
+      <h1 className="text-3xl font-bold">Dashboard</h1>
+      <p className="mt-2 text-muted-foreground">Minimal dashboard page</p>
+    </div>
+  )
+}
+`
+if (fs.existsSync(appDashboardPagePath)) {
+  // Move old dashboard page.tsx to _sample_content
+  const oldDashDest = path.join(sampleContentDir, 'app/dashboard/page.tsx')
+  const oldDashDir = path.dirname(oldDashDest)
+  if (!fs.existsSync(oldDashDir)) fs.mkdirSync(oldDashDir, { recursive: true })
+  fs.copyFileSync(appDashboardPagePath, oldDashDest)
+
+  fs.writeFileSync(appDashboardPagePath, appDashboardPageContent)
+  console.log('Reset: app/dashboard/page.tsx')
+}
+
+console.log(
+  'Cleanup complete! Check the _sample_content directory for the previous sample components and pages.'
+)

--- a/scripts/restore.mjs
+++ b/scripts/restore.mjs
@@ -1,0 +1,78 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const projectRoot = path.join(__dirname, '..')
+const sampleContentDir = path.join(projectRoot, '_sample_content')
+
+if (!fs.existsSync(sampleContentDir)) {
+  console.log('No _sample_content directory found. Nothing to restore.')
+  process.exit(0)
+}
+
+const itemsToRestore = [
+  'app/docs',
+  'components/docs',
+  'components/landing',
+  'components/dashboard',
+  'app/page.tsx',
+  'app/dashboard/page.tsx',
+]
+
+console.log('Restoring from _sample_content directory...')
+
+itemsToRestore.forEach((itemPath) => {
+  const sourcePath = path.join(sampleContentDir, itemPath)
+  if (fs.existsSync(sourcePath)) {
+    const destPath = path.join(projectRoot, itemPath)
+    const targetDir = path.dirname(destPath)
+
+    if (!fs.existsSync(targetDir)) {
+      fs.mkdirSync(targetDir, { recursive: true })
+    }
+
+    // If the destination is a directory, fs.renameSync works directly.
+    // If it's a file and it exists, we overwrite it.
+    if (fs.existsSync(destPath) && fs.statSync(destPath).isFile()) {
+      fs.rmSync(destPath)
+    }
+
+    fs.renameSync(sourcePath, destPath)
+    console.log(`Restored: ${itemPath}`)
+  } else {
+    console.log(`Skipped: ${itemPath} (not found in _sample_content)`)
+  }
+})
+
+// Clean up the _sample_content directory if it's empty after restore
+const cleanEmptyFoldersRecursively = (folder) => {
+  if (!fs.existsSync(folder)) return
+
+  const files = fs.readdirSync(folder)
+  if (files.length > 0) {
+    files.forEach((file) => {
+      const fullPath = path.join(folder, file)
+      if (fs.statSync(fullPath).isDirectory()) {
+        cleanEmptyFoldersRecursively(fullPath)
+      }
+    })
+
+    // Re-evaluate if the folder is empty after cleaning its children
+    if (fs.readdirSync(folder).length === 0) {
+      fs.rmdirSync(folder)
+    }
+  } else {
+    fs.rmdirSync(folder)
+  }
+}
+
+cleanEmptyFoldersRecursively(sampleContentDir)
+
+if (!fs.existsSync(sampleContentDir)) {
+  console.log('Removed empty _sample_content directory.')
+}
+
+console.log('Restore complete!')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "_sample_content"]
 }


### PR DESCRIPTION
## Description

We now have the option to run a script to clean the template and remove temporary pages used on the landing.

## Related Issues

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `npm run clean` command to reset the project to a minimal Next.js boilerplate, archiving sample pages.
  * Added `npm run restore` command to restore archived sample pages.
  * Project renamed to "nexion".

* **Documentation**
  * Updated Getting Started guide with instructions for cleaning and restoring sample UI pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->